### PR TITLE
Fix conflict with other plugins patching the same method

### DIFF
--- a/lib/redmine_quick_replies/patches/wiki_formatting_patch.rb
+++ b/lib/redmine_quick_replies/patches/wiki_formatting_patch.rb
@@ -1,20 +1,15 @@
 module RedmineQuickReplies
   module Patches
     module WikiFormattingPatch
-      def self.included(base) # :nodoc:
-        base.send(:include, InstanceMethods)
+      extend ActiveSupport::Concern
 
-        base.class_eval do
-          unloadable # Send unloadable so it will not be unloaded in development
-
-          alias_method :heads_for_wiki_formatter_without_redmine_quick_replies, :heads_for_wiki_formatter
-          alias_method :heads_for_wiki_formatter, :heads_for_wiki_formatter_with_redmine_quick_replies
-        end
+      included do
+        prepend InstanceOverwriteMethods
       end
 
-      module InstanceMethods
-        def heads_for_wiki_formatter_with_redmine_quick_replies
-            heads_for_wiki_formatter_without_redmine_quick_replies
+      module InstanceOverwriteMethods
+        def heads_for_wiki_formatter
+          super
 
             return if @heads_for_wiki_redmine_quick_replies_included
 

--- a/lib/redmine_quick_replies/patches/wiki_formatting_patch.rb
+++ b/lib/redmine_quick_replies/patches/wiki_formatting_patch.rb
@@ -11,19 +11,19 @@ module RedmineQuickReplies
         def heads_for_wiki_formatter
           super
 
-            return if @heads_for_wiki_redmine_quick_replies_included
+          return if @heads_for_wiki_redmine_quick_replies_included
 
-            content_for :header_tags do
-                replies = Reply.visible.sorted.to_json
+          content_for :header_tags do
+            replies = Reply.visible.sorted.to_json
 
-                o = javascript_tag("redmine_quick_replies = " + replies + ";")
-                o << javascript_include_tag('replies', :plugin => 'redmine_quick_replies')
-                o << stylesheet_link_tag('replies', :plugin => 'redmine_quick_replies')
-                o.html_safe
-            end
-
-            @heads_for_wiki_redmine_quick_replies_included = true
+            o = javascript_tag("redmine_quick_replies = " + replies + ";")
+            o << javascript_include_tag('replies', :plugin => 'redmine_quick_replies')
+            o << stylesheet_link_tag('replies', :plugin => 'redmine_quick_replies')
+            o.html_safe
           end
+
+          @heads_for_wiki_redmine_quick_replies_included = true
+        end
       end
     end
   end


### PR DESCRIPTION
Hi!

When installing this plugin, I noticed a conflict with an other plugin causing 500 errors on any page with a text area. According to redmine logs, an infinite recursive call occur between two patches trying to patch the `heads_for_wiki_formatter` method.

The conflicting patches in question:
* [AlphaNodes/additionals:/lib/additionals/patches/formatting_helper_patch.rb](https://github.com/AlphaNodes/additionals/blob/master/lib/additionals/patches/formatting_helper_patch.rb)
* [eXolnet/redmine_quick_replies:/lib/redmine_quick_replies/patches/wiki_formatting_patch.rb](https://github.com/eXolnet/redmine_quick_replies/blob/master/lib/redmine_quick_replies/patches/wiki_formatting_patch.rb)

This PR fix the way the `heads_for_wiki_formatter` method is patch.

I have tested this PR on our staging area and it does fix the issue. Let me know if you have any comments on the PR.

Thanks!